### PR TITLE
Typo: incorrect shared library directory

### DIFF
--- a/README
+++ b/README
@@ -80,7 +80,7 @@ installed into, or be accessible by, each jail individually in order to
 enforce security policies inside of the jail.
 
 Note: if jails are setup to use a read-only basejail, manual installation
-of libsecadm.0.so into the basejail's /var/lib directory is required.
+of libsecadm.0.so into the basejail's /usr/lib directory is required.
 
 Writing Application Rules
 =========================


### PR DESCRIPTION
In the "Installing to a Jail" section, /var/lib is incorrect and should be /usr/lib