### PR TITLE
Separate build by use-case.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Build everything unless explicitly overridden
 
 # ports/hardenedbsd/secadm-kmod
-.if ! defined(WITHOUT_KMOD)
+.if !defined(WITHOUT_KMOD)
 SUBDIR+=	kmod
 .endif
 
 # ports/hardenedbsd/secadm
-.if ! defined(WITHOUT_CLI)
+.if !defined(WITHOUT_CLI)
 SUBDIR+=	etc \
 		libsecadm \
 		secadm

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,13 @@
-# Build everything by default
-SUBDIR=		etc\
-		kmod \
-		libsecadm \
-		secadm
+# Build everything unless explicitly overridden
 
 # ports/hardenedbsd/secadm-kmod
-.if defined(KMOD)
-SUBDIR=		kmod
+.if ! defined(WITHOUT_KMOD)
+SUBDIR+=	kmod
 .endif
 
 # ports/hardenedbsd/secadm
-.if defined(CLI)
-SUBDIR=		etc \
+.if ! defined(WITHOUT_CLI)
+SUBDIR+=	etc \
 		libsecadm \
 		secadm
 .endif

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
-SUBDIR+=	etc \
+# Build everything by default
+SUBDIR=		etc\
 		kmod \
 		libsecadm \
 		secadm
+
+# ports/hardenedbsd/secadm-kmod
+.if defined(KMOD)
+SUBDIR=		kmod
+.endif
+
+# ports/hardenedbsd/secadm
+.if defined(CLI)
+SUBDIR=		etc \
+		libsecadm \
+		secadm
+.endif
 
 .include <bsd.subdir.mk>


### PR DESCRIPTION
* leave `all` target unchanged
* check if CLI is defined for ports/hardenedbsd/secadm
* check if KMOD is defined for ports/hardenedbsd/secadm-kmod